### PR TITLE
added -e flag to exit in case of error

### DIFF
--- a/pefssetup
+++ b/pefssetup
@@ -1,4 +1,4 @@
-#!/bin/tcsh
+#!/bin/tcsh -e
 # James Glossinger
 # usage: pefssetup usertosetup
 ############


### PR DESCRIPTION
Without the -e flag, the following can happen:
If rsync isn't installed, then the home directory is deleted even though the copy failed.