### PR TITLE
added some flags to commands that can fail

### DIFF
--- a/pefssetup
+++ b/pefssetup
@@ -3,7 +3,7 @@
 # usage: pefssetup usertosetup
 ############
 pkg install pefs-kmod
-kldload pefs
+kldload -n pefs
 sleep 5
 sed -i '' '/pefs/d' /boot/loader.conf
 echo 'pefs_load="YES"' >> /boot/loader.conf
@@ -12,7 +12,7 @@ set usertosetup=$1
 echo 'Copying user directory to user.old'
 rsync -av /usr/home/$usertosetup/ /usr/home/$usertosetup.old
 echo 'Removing keychain from backup if it exists, so we dont write over the real one later.'
-rm /usr/home/$usertosetup.old/.pefs.db
+rm -f /usr/home/$usertosetup.old/.pefs.db
 echo 'Unmounting user directory.'
 umount /usr/home/$usertosetup
 echo 'Removing old user directory.'


### PR DESCRIPTION
The `-e` flag for tcsh stops the script if something fails. After trying the script again on another machine I noticed that I need to add flags to `kldload` and `rm`, since failure is permitted here.